### PR TITLE
First cut at a merge-branch directive (precursor to pull-request -> internal draft workspace feature).

### DIFF
--- a/java/com/google/devtools/moe/client/codebase/LocalWorkspace.java
+++ b/java/com/google/devtools/moe/client/codebase/LocalWorkspace.java
@@ -10,11 +10,11 @@ import java.io.File;
 import javax.annotation.Nullable;
 
 /**
- * Operations for objects encapsulating a local clone ('hg clone', 'git clone', 'svn checkout') of
- * a remote repository to disk.
+ * Operations for objects encapsulating a local workspace/clone/client of a repository
+ * (e.g. {@code hg clone}, {@code git clone}, {@code svn checkout}).
  *
  */
-public interface LocalClone {
+public interface LocalWorkspace {
 
   /**
    * Returns the name of the cloned {@link com.google.devtools.moe.client.repositories.Repository}.

--- a/java/com/google/devtools/moe/client/directives/BookkeepingDirective.java
+++ b/java/com/google/devtools/moe/client/directives/BookkeepingDirective.java
@@ -12,8 +12,6 @@ import com.google.devtools.moe.client.testing.DummyDb;
 
 import org.kohsuke.args4j.Option;
 
-import java.util.List;
-
 import javax.inject.Inject;
 
 /**
@@ -46,9 +44,7 @@ public class BookkeepingDirective extends Directive {
         return 1;
       }
     }
-
-    List<String> names = context().migrationConfigs.keySet().asList();
-    return BookkeepingLogic.bookkeep(names, db, dbLocation, context());
+    return BookkeepingLogic.bookkeep(db, dbLocation, context());
   }
 
   @Override

--- a/java/com/google/devtools/moe/client/directives/DirectivesModule.java
+++ b/java/com/google/devtools/moe/client/directives/DirectivesModule.java
@@ -83,6 +83,12 @@ public class DirectivesModule {
   }
 
   @Provides(type = MAP)
+  @StringKey("migrate_branch")
+  Directive migrateBranch(MigrateBranchDirective directive) {
+    return directive;
+  }
+
+  @Provides(type = MAP)
   @StringKey("merge_codebases")
   Directive mergeCodebases(MergeCodebasesDirective directive) {
     return directive;

--- a/java/com/google/devtools/moe/client/directives/MigrateBranchDirective.java
+++ b/java/com/google/devtools/moe/client/directives/MigrateBranchDirective.java
@@ -1,0 +1,180 @@
+// Copyright 2011 The MOE Authors All Rights Reserved.
+
+package com.google.devtools.moe.client.directives;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.devtools.moe.client.MoeProblem;
+import com.google.devtools.moe.client.Ui;
+import com.google.devtools.moe.client.database.RepositoryEquivalence;
+import com.google.devtools.moe.client.logic.OneMigrationLogic;
+import com.google.devtools.moe.client.migrations.Migration;
+import com.google.devtools.moe.client.migrations.MigrationConfig;
+import com.google.devtools.moe.client.parser.Expression;
+import com.google.devtools.moe.client.parser.RepositoryExpression;
+import com.google.devtools.moe.client.project.ProjectContextFactory;
+import com.google.devtools.moe.client.project.RepositoryConfig;
+import com.google.devtools.moe.client.repositories.ExactRevisionMatcher;
+import com.google.devtools.moe.client.repositories.Repositories;
+import com.google.devtools.moe.client.repositories.Repository;
+import com.google.devtools.moe.client.repositories.Revision;
+import com.google.devtools.moe.client.repositories.RevisionHistory;
+import com.google.devtools.moe.client.repositories.RevisionHistory.SearchType;
+import com.google.devtools.moe.client.writer.DraftRevision;
+import com.google.devtools.moe.client.writer.Writer;
+import com.google.devtools.moe.client.writer.WritingError;
+
+import org.kohsuke.args4j.Option;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+/**
+ * Perform a one-directional merge from a branch (and specified branch point) onto the head
+ * of the target repository.
+ *
+ * <p>This is effectively works like the {@link MagicDirective} except that it only passes in one
+ * direction, and does no bookkeeping.
+ *
+ * @author cgruber@google.com (Christian Gruber)
+ */
+public class MigrateBranchDirective extends Directive {
+  @Option(name = "--from_repository", required = true, usage = "The label of the source repository")
+  String fromRepository = "";
+
+  @Option(name = "--branch", required = true, usage = "the symbolic name of the imported branch")
+  String branchLabel = "";
+
+  @Option(
+      name = "--branch_root",
+      required = true,
+      usage = "the commit that constitutes the starting point for branch replay.")
+  // TODO(cgruber) turn this into a Revision against the repo in question via an args factory
+  String branchPoint = "";
+
+  private Repositories repositories;
+  private final Ui ui;
+
+  @Inject
+  MigrateBranchDirective(ProjectContextFactory contextFactory, Repositories repositories, Ui ui) {
+    super(contextFactory);
+    this.repositories = repositories;
+    this.ui = ui;
+  }
+
+  @Override
+  protected int performDirectiveBehavior() {
+    List<MigrationConfig> configs =
+        FluentIterable.from(context().migrationConfigs.values())
+            .filter(new Predicate<MigrationConfig>() {
+              @Override public boolean apply(MigrationConfig input) {
+                return input.getFromRepository().equals(fromRepository);
+              }
+            })
+            .toList();
+    switch (configs.size()) {
+      case 0:
+        ui.error("No migration configurations could be found from repository '%s'", fromRepository);
+        return 1;
+      case 1:
+        break;
+      default:
+        // TODO(cgruber) Allow specification of a migration if there are more than one.
+        ui.error("More than one migration configuration from repository '%s'", fromRepository);
+        return 1;
+    }
+    MigrationConfig migrationConfig = Iterables.getOnlyElement(configs);
+    Ui.Task migrationTask =
+        ui.pushTask(
+            "perform_migration", "Performing migration '%s' from branch '%s'",
+            migrationConfig.getName(),
+            branchLabel);
+    List<Migration> migrations = determineMigrations(migrationConfig);
+    if (migrations.isEmpty()) {
+      ui.info("No pending revisions to migrate in branch '%s' (as of %s)", branchLabel, "");
+      return 0;
+    }
+
+    RepositoryExpression toRepo = new RepositoryExpression(migrationConfig.getToRepository());
+    Writer toWriter;
+    try {
+      toWriter = toRepo.createWriter(context());
+    } catch (WritingError e) {
+      throw new MoeProblem("Couldn't create local repo %s: %s", toRepo, e);
+    }
+
+    DraftRevision dr = null; // Store one draft revision to obtain workspace location for UI.
+    for (Migration m : migrations) {
+      // For each migration, the reference to-codebase for inverse translation is the Writer,
+      // since it contains the latest changes (i.e. previous migrations) to the to-repository.
+      Expression referenceToCodebase =
+          new RepositoryExpression(migrationConfig.getToRepository())
+              .withOption("localroot", toWriter.getRoot().getAbsolutePath());
+
+      Ui.Task oneMigrationTask =
+          ui.pushTask(
+              "perform_individual_migration",
+              String.format("Performing individual migration '%s'", m.toString()));
+      dr = OneMigrationLogic.migrate(m, context(), toWriter, referenceToCodebase);
+      ui.popTask(oneMigrationTask, "");
+    }
+    toWriter.printPushMessage();
+    ui.popTaskAndPersist(migrationTask, toWriter.getRoot());
+    ui.info(
+        "Created Draft workspace:\n%s in repository '%s'",
+        dr.getLocation(),
+        toRepo.getRepositoryName());
+    return 0;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Updates database and performs all migrations";
+  }
+
+  private List<Migration> determineMigrations(MigrationConfig migrationConfig) {
+    String fromRepoName = migrationConfig.getFromRepository();
+    RepositoryConfig fromRepoConfig =
+        context().config.getRepositoryConfig(fromRepoName).copyWithBranch(branchLabel);
+    Repository fromRepo = repositories.create(fromRepoName, fromRepoConfig);
+    Revision branchPointRevision = Revision.create(branchPoint, fromRepoName);
+    RevisionHistory history = fromRepo.revisionHistory();
+
+    ExactRevisionMatcher.Result match =
+        history.findRevisions(
+            null, // Start at branch tip.
+            new ExactRevisionMatcher(branchPointRevision),
+            SearchType.LINEAR);
+    // Since the matcher crawls from head, revisions() are in the opposite order from what
+    // we want to replay.
+    List<Revision> toMigrate = Lists.reverse(match.revisions().getBreadthFirstHistory());
+
+    Revision toHead = context()
+        .getRepository(migrationConfig.getToRepository())
+        .revisionHistory()
+        .findHighestRevision(null);
+    RepositoryEquivalence migrationRoot = RepositoryEquivalence.create(branchPointRevision, toHead);
+
+    ui.info(
+        "Migrating %d revisions in %s (branch %s) from %s: %s",
+        toMigrate.size(),
+        migrationConfig.getFromRepository(),
+        branchLabel,
+        branchPointRevision,
+        Joiner.on(", ").join(toMigrate));
+    if (migrationConfig.getSeparateRevisions()) {
+      ImmutableList.Builder<Migration> migrations = ImmutableList.builder();
+      for (Revision fromRev : toMigrate) {
+        migrations.add(new Migration(migrationConfig, ImmutableList.of(fromRev), migrationRoot));
+      }
+      return migrations.build();
+    } else {
+      return ImmutableList.of(new Migration(migrationConfig, toMigrate, migrationRoot));
+    }
+  }
+}

--- a/java/com/google/devtools/moe/client/directives/OneMigrationDirective.java
+++ b/java/com/google/devtools/moe/client/directives/OneMigrationDirective.java
@@ -64,9 +64,9 @@ public class OneMigrationDirective extends Directive {
 
     List<Revision> revs = Revision.fromRepositoryExpression(fromRepoEx, context());
 
-    Codebase c;
+    Codebase sourceCodebase;
     try {
-      c =
+      sourceCodebase =
           new RepositoryExpression(fromRepoEx.getRepositoryName())
               .atRevision(revs.get(0).revId())
               .translateTo(toProjectSpace)
@@ -88,7 +88,7 @@ public class OneMigrationDirective extends Directive {
 
     DraftRevision r =
         OneMigrationLogic.migrate(
-            c,
+            sourceCodebase,
             destination,
             revs,
             context(),

--- a/java/com/google/devtools/moe/client/dvcs/AbstractDvcsCodebaseCreator.java
+++ b/java/com/google/devtools/moe/client/dvcs/AbstractDvcsCodebaseCreator.java
@@ -9,7 +9,7 @@ import com.google.devtools.moe.client.Utils;
 import com.google.devtools.moe.client.codebase.Codebase;
 import com.google.devtools.moe.client.codebase.CodebaseCreationError;
 import com.google.devtools.moe.client.codebase.CodebaseCreator;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.parser.RepositoryExpression;
 import com.google.devtools.moe.client.parser.Term;
 import com.google.devtools.moe.client.repositories.Revision;
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public abstract class AbstractDvcsCodebaseCreator implements CodebaseCreator {
 
-  private final Supplier<? extends LocalClone> headCloneSupplier;
+  private final Supplier<? extends LocalWorkspace> headCloneSupplier;
   private final RevisionHistory revisionHistory;
   private final String projectSpace;
 
@@ -38,7 +38,7 @@ public abstract class AbstractDvcsCodebaseCreator implements CodebaseCreator {
   // TODO(user): Find a better semantics for when a Supplier provides a new clone every time,
   // or just one clone via memoization, so that the meaning of headCloneSupplier.get() is clearer.
   public AbstractDvcsCodebaseCreator(
-      Supplier<? extends LocalClone> headCloneSupplier,
+      Supplier<? extends LocalWorkspace> headCloneSupplier,
       RevisionHistory revisionHistory,
       String projectSpace) {
     this.headCloneSupplier = headCloneSupplier;
@@ -55,11 +55,11 @@ public abstract class AbstractDvcsCodebaseCreator implements CodebaseCreator {
    * @param localroot  the absolute path of the local clone to re-clone
    * @return a LocalClone of the re-clone
    */
-  protected abstract LocalClone cloneAtLocalRoot(String localroot);
+  protected abstract LocalWorkspace cloneAtLocalRoot(String localroot);
 
   @Override
   public Codebase create(Map<String, String> options) throws CodebaseCreationError {
-    LocalClone headClone;
+    LocalWorkspace headClone;
     File archiveLocation;
     String localRoot = options.get("localroot");
     if (Strings.isNullOrEmpty(localRoot)) {

--- a/java/com/google/devtools/moe/client/dvcs/AbstractDvcsWriter.java
+++ b/java/com/google/devtools/moe/client/dvcs/AbstractDvcsWriter.java
@@ -9,7 +9,7 @@ import com.google.devtools.moe.client.Injector;
 import com.google.devtools.moe.client.MoeProblem;
 import com.google.devtools.moe.client.Utils;
 import com.google.devtools.moe.client.codebase.Codebase;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.repositories.RevisionMetadata;
 import com.google.devtools.moe.client.writer.DraftRevision;
 import com.google.devtools.moe.client.writer.Writer;
@@ -28,7 +28,7 @@ import java.util.Set;
  *
  */
 // TODO(user): Make this usable for SVN as well.
-public abstract class AbstractDvcsWriter<T extends LocalClone> implements Writer {
+public abstract class AbstractDvcsWriter<T extends LocalWorkspace> implements Writer {
 
   /**
    * The LocalClone in which this writer should make and commit changes.

--- a/java/com/google/devtools/moe/client/dvcs/DvcsDraftRevision.java
+++ b/java/com/google/devtools/moe/client/dvcs/DvcsDraftRevision.java
@@ -2,7 +2,7 @@
 
 package com.google.devtools.moe.client.dvcs;
 
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.writer.DraftRevision;
 
 /**
@@ -11,9 +11,9 @@ import com.google.devtools.moe.client.writer.DraftRevision;
  */
 public class DvcsDraftRevision implements DraftRevision {
 
-  private final LocalClone revClone;
+  private final LocalWorkspace revClone;
 
-  public DvcsDraftRevision(LocalClone revClone) {
+  public DvcsDraftRevision(LocalWorkspace revClone) {
     this.revClone = revClone;
   }
 

--- a/java/com/google/devtools/moe/client/dvcs/git/GitClonedRepository.java
+++ b/java/com/google/devtools/moe/client/dvcs/git/GitClonedRepository.java
@@ -11,16 +11,16 @@ import com.google.devtools.moe.client.FileSystem.Lifetime;
 import com.google.devtools.moe.client.Injector;
 import com.google.devtools.moe.client.Lifetimes;
 import com.google.devtools.moe.client.MoeProblem;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.project.RepositoryConfig;
 
 import java.io.File;
 import java.io.IOException;
 
 /**
- * Git implementation of {@link LocalClone}, i.e. a 'git clone' to local disk.
+ * Git implementation of {@link LocalWorkspace}, i.e. a 'git clone' to local disk.
  */
-public class GitClonedRepository implements LocalClone {
+public class GitClonedRepository implements LocalWorkspace {
 
   /**
    * A prefix for branches MOE creates to write migrated changes. For example, if there have been
@@ -76,10 +76,12 @@ public class GitClonedRepository implements LocalClone {
   public void cloneLocallyAtHead(Lifetime cloneLifetime) {
     Preconditions.checkState(!clonedLocally);
 
-    String tempDirName = "git_clone_" + repositoryName + "_";
+    Optional<String> branchName = repositoryConfig.getBranch();
+    String tempDirName = branchName.isPresent()
+        ? "git_clone_" + repositoryName + "_" + branchName.get() + "_"
+        : "git_clone_" + repositoryName + "_";
     localCloneTempDir =
         Injector.INSTANCE.fileSystem().getTemporaryDirectory(tempDirName, cloneLifetime);
-    Optional<String> branchName = repositoryConfig.getBranch();
 
     try {
       ImmutableList.Builder<String> cloneArgs = ImmutableList.<String>builder();

--- a/java/com/google/devtools/moe/client/dvcs/git/GitCodebaseCreator.java
+++ b/java/com/google/devtools/moe/client/dvcs/git/GitCodebaseCreator.java
@@ -4,7 +4,7 @@ package com.google.devtools.moe.client.dvcs.git;
 
 import com.google.common.base.Supplier;
 import com.google.devtools.moe.client.Lifetimes;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.dvcs.AbstractDvcsCodebaseCreator;
 import com.google.devtools.moe.client.project.RepositoryConfig;
 import com.google.devtools.moe.client.repositories.RevisionHistory;
@@ -19,7 +19,7 @@ public class GitCodebaseCreator extends AbstractDvcsCodebaseCreator {
   private final RepositoryConfig config;
 
   public GitCodebaseCreator(
-      Supplier<? extends LocalClone> headCloneSupplier,
+      Supplier<? extends LocalWorkspace> headCloneSupplier,
       RevisionHistory revisionHistory,
       String projectSpace,
       String repositoryName,
@@ -30,7 +30,7 @@ public class GitCodebaseCreator extends AbstractDvcsCodebaseCreator {
   }
 
   @Override
-  protected LocalClone cloneAtLocalRoot(String localroot) {
+  protected LocalWorkspace cloneAtLocalRoot(String localroot) {
     GitClonedRepository clone = new GitClonedRepository(repositoryName, config, localroot);
     clone.cloneLocallyAtHead(Lifetimes.currentTask());
     return clone;

--- a/java/com/google/devtools/moe/client/dvcs/hg/HgClonedRepository.java
+++ b/java/com/google/devtools/moe/client/dvcs/hg/HgClonedRepository.java
@@ -13,7 +13,7 @@ import com.google.devtools.moe.client.FileSystem.Lifetime;
 import com.google.devtools.moe.client.Injector;
 import com.google.devtools.moe.client.Lifetimes;
 import com.google.devtools.moe.client.MoeProblem;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.project.RepositoryConfig;
 
 import java.io.File;
@@ -23,7 +23,7 @@ import java.io.IOException;
  * Hg implementation of LocalClone, i.e. an 'hg clone' to local disk.
  *
  */
-public class HgClonedRepository implements LocalClone {
+public class HgClonedRepository implements LocalWorkspace {
 
   private final String repositoryName;
   private final RepositoryConfig repositoryConfig;

--- a/java/com/google/devtools/moe/client/dvcs/hg/HgCodebaseCreator.java
+++ b/java/com/google/devtools/moe/client/dvcs/hg/HgCodebaseCreator.java
@@ -4,7 +4,7 @@ package com.google.devtools.moe.client.dvcs.hg;
 
 import com.google.common.base.Supplier;
 import com.google.devtools.moe.client.Lifetimes;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.dvcs.AbstractDvcsCodebaseCreator;
 import com.google.devtools.moe.client.project.RepositoryConfig;
 import com.google.devtools.moe.client.repositories.RevisionHistory;
@@ -19,7 +19,7 @@ public class HgCodebaseCreator extends AbstractDvcsCodebaseCreator {
   private final RepositoryConfig config;
 
   public HgCodebaseCreator(
-      Supplier<? extends LocalClone> headCloneSupplier,
+      Supplier<? extends LocalWorkspace> headCloneSupplier,
       RevisionHistory revisionHistory,
       String projectSpace,
       String repositoryName,
@@ -30,7 +30,7 @@ public class HgCodebaseCreator extends AbstractDvcsCodebaseCreator {
   }
 
   @Override
-  protected LocalClone cloneAtLocalRoot(String localroot) {
+  protected LocalWorkspace cloneAtLocalRoot(String localroot) {
     HgClonedRepository clone = new HgClonedRepository(repositoryName, config, localroot);
     clone.cloneLocallyAtHead(Lifetimes.currentTask());
     return clone;

--- a/java/com/google/devtools/moe/client/project/InvalidProject.java
+++ b/java/com/google/devtools/moe/client/project/InvalidProject.java
@@ -8,7 +8,7 @@ import com.google.common.base.Strings;
  *
  * @author dbentley@google.com (Daniel Bentley)
  */
-public class InvalidProject extends Exception {
+public class InvalidProject extends RuntimeException {
   public InvalidProject(String explanationTemplate, Object... args) {
     super(String.format(explanationTemplate, args));
   }

--- a/java/com/google/devtools/moe/client/project/RepositoryConfig.java
+++ b/java/com/google/devtools/moe/client/project/RepositoryConfig.java
@@ -6,6 +6,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.devtools.moe.client.repositories.Repository;
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -123,6 +124,16 @@ public class RepositoryConfig {
           getType(),
           repositoryFactory.getClass().getSimpleName());
     }
+  }
+
+  /**
+   * Modified copy creator.
+   */
+  public RepositoryConfig copyWithBranch(String branch) {
+    Gson gson = new Gson(); // Clone using Gson to ensure all things are serialized.
+    RepositoryConfig newConfig = gson.fromJson(gson.toJsonTree(this), getClass());
+    newConfig.branch = branch;
+    return newConfig;
   }
 
   @SuppressWarnings("unused")

--- a/java/com/google/devtools/moe/client/repositories/ExactRevisionMatcher.java
+++ b/java/com/google/devtools/moe/client/repositories/ExactRevisionMatcher.java
@@ -1,0 +1,66 @@
+// Copyright 2015 The MOE Authors All Rights Reserved.
+
+package com.google.devtools.moe.client.repositories;
+
+import com.google.auto.value.AutoValue;
+import com.google.devtools.moe.client.MoeProblem;
+import com.google.devtools.moe.client.database.RepositoryEquivalenceMatcher;
+
+import java.util.List;
+
+/**
+ * A RevisionMatcher is used to crawl a repository's revision history, stopping at matching
+ * Revisions, and returning an arbitrary result depending on the non-matching and matching
+ * Revisions found.
+ */
+public class ExactRevisionMatcher implements RevisionMatcher<ExactRevisionMatcher.Result> {
+  private final Revision branchPointRevision;
+
+  public ExactRevisionMatcher(Revision branchPointRevision) {
+    this.branchPointRevision = branchPointRevision;
+  }
+
+  /**
+   * Returns whether this Revision matches. If it doesn't, then history-crawling should continue
+   * through its parents.
+   */
+  @Override
+  public boolean matches(Revision revision) {
+    return revision.equals(branchPointRevision);
+  }
+
+  /**
+   * Returns a result of crawling a repository's revision history, along a branch, back to a
+   * specific branch point.
+   */
+  @Override
+  public ExactRevisionMatcher.Result
+      makeResult(RevisionGraph nonMatching, List<Revision> matching) {
+    switch (matching.size()) {
+      case 0:
+        throw new MoeProblem(
+            "No matching revisions in history. The branch may have no commits or be mislabeled.");
+      case 1:
+        return Result.create(nonMatching);
+      default:
+        throw new MoeProblem("Revision history matched %s branch points", matching.size());
+    }
+  }
+
+  /**
+   * The result of crawling a revision history with a {@link RepositoryEquivalenceMatcher}.
+   * Stores the revisions found since any equivalence, and the equivalences themselves.
+   */
+  @AutoValue
+  public abstract static class Result {
+    /**
+     * Returns a {@link RevisionGraph} of Revisions since equivalence, or since the start of repo
+     * history if no equivalence was found.
+     */
+    public abstract RevisionGraph revisions();
+
+    static Result create(RevisionGraph revisions) {
+      return new AutoValue_ExactRevisionMatcher_Result(revisions);
+    }
+  }
+}

--- a/javatests/com/google/devtools/moe/client/dvcs/AbstractDvcsCodebaseCreatorTest.java
+++ b/javatests/com/google/devtools/moe/client/dvcs/AbstractDvcsCodebaseCreatorTest.java
@@ -12,7 +12,7 @@ import com.google.devtools.moe.client.FileSystem;
 import com.google.devtools.moe.client.Injector;
 import com.google.devtools.moe.client.SystemCommandRunner;
 import com.google.devtools.moe.client.codebase.Codebase;
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 import com.google.devtools.moe.client.project.RepositoryConfig;
 import com.google.devtools.moe.client.repositories.Revision;
 import com.google.devtools.moe.client.repositories.RevisionHistory;
@@ -41,12 +41,12 @@ public class AbstractDvcsCodebaseCreatorTest extends TestCase {
   private final FileSystem mockFS = control.createMock(FileSystem.class);
   private final RepositoryConfig mockRepoConfig = control.createMock(RepositoryConfig.class);
 
-  private final LocalClone mockRepo = control.createMock(LocalClone.class);
+  private final LocalWorkspace mockRepo = control.createMock(LocalWorkspace.class);
   private final RevisionHistory mockRevHistory = control.createMock(RevisionHistory.class);
   private final AbstractDvcsCodebaseCreator codebaseCreator =
       new AbstractDvcsCodebaseCreator(Suppliers.ofInstance(mockRepo), mockRevHistory, "public") {
         @Override
-        protected LocalClone cloneAtLocalRoot(String localroot) {
+        protected LocalWorkspace cloneAtLocalRoot(String localroot) {
           throw new UnsupportedOperationException();
         }
       };

--- a/javatests/com/google/devtools/moe/client/dvcs/DvcsDraftRevisionTest.java
+++ b/javatests/com/google/devtools/moe/client/dvcs/DvcsDraftRevisionTest.java
@@ -4,7 +4,7 @@ package com.google.devtools.moe.client.dvcs;
 
 import static org.easymock.EasyMock.expect;
 
-import com.google.devtools.moe.client.codebase.LocalClone;
+import com.google.devtools.moe.client.codebase.LocalWorkspace;
 
 import junit.framework.TestCase;
 
@@ -21,7 +21,7 @@ public class DvcsDraftRevisionTest extends TestCase {
     final File mockRepoPath = new File("/mockrepo");
 
     IMocksControl control = EasyMock.createControl();
-    LocalClone mockRevClone = control.createMock(LocalClone.class);
+    LocalWorkspace mockRevClone = control.createMock(LocalWorkspace.class);
     expect(mockRevClone.getLocalTempDir()).andReturn(mockRepoPath);
 
     control.replay();

--- a/javatests/com/google/devtools/moe/client/dvcs/git/GitClonedRepositoryTest.java
+++ b/javatests/com/google/devtools/moe/client/dvcs/git/GitClonedRepositoryTest.java
@@ -107,7 +107,8 @@ public class GitClonedRepositoryTest extends TestCase {
     expect(repositoryConfig.getBranch()).andReturn(Optional.of("mybranch")).anyTimes();
 
     expect(mockFS.getTemporaryDirectory(
-              EasyMock.eq("git_clone_" + repositoryName + "_"), EasyMock.<Lifetime>anyObject()))
+              EasyMock.eq("git_clone_" + repositoryName + "_mybranch_"),
+              EasyMock.<Lifetime>anyObject()))
         .andReturn(new File(localCloneTempDir));
 
     expect(cmd.runCommand(


### PR DESCRIPTION
This CL adds the new directive, hooks it up, and does a bit of renaming, and does some gross copy-factory-method stuff to gson objects.

This version of the directive assumes an existing bi-directional moe configuration (migrations from/to internal to/from external) and the associated translators (a pretty typical setup for most MOE projects.)

To this standard config, one adds

  * `--from_repository=repo_name (the moe_config name of the repo)`
  * `--branch=branch_label (symbolic name of the branch in the version control system)`
  * `--branch_root=<refId> (the point at which the branch diverged from master)`

The directive then performs a single migration, mirroring the inbound migration, but from the branch, and replaying onto head (ignoring any equivalence issues).

Aside from github (or any other front-end) related enhancements as such, this needs refinement.  Notably:

  * calculation of the branch_root as the point of deviation from master (eliminate a flag)
  * Optionally allow for it to figure out a root from equivalence, to make the initial merge easier (probably don't care about this much)
  * Internal redesign to explode ProjectContext in order to
    - avoid having to fake MigrationConfig and RepositoryConfig from the ProjectContext
    - Make testing vastly easier (too much test-staging and mocking needed at present)
    - Make it possible for a lot of the logic to be hosted in the graph
    - Allow a lot less initialization of repo stuff in order to just get a part it spun up
    - Allow for way better user experience (hijacking mechanisms uses their logging)

Next steps beyond refinement - a directive to decompose a pull request and harness this feature to provide a pull-request->draft-workspace import, making it trivial to bring in a change from a pull request.

-------------

Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=99521404