### PR TITLE
Treat '_' underscore as word character

### DIFF
--- a/client/src/main/java/com/google/devtools/moe/client/parser/Parser.java
+++ b/client/src/main/java/com/google/devtools/moe/client/parser/Parser.java
@@ -270,6 +270,7 @@ public class Parser {
     result.wordChars('a', 'z');
     result.wordChars('A', 'Z');
     result.wordChars('0', '9');
+    result.wordChars('_', '_');
     result.whitespaceChars(0, 32);
     result.quoteChar('"');
 


### PR DESCRIPTION
Allow to specify repository_names_with_underscore without using double quotes in command line options.